### PR TITLE
LaTeX transformer

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,19 +31,20 @@
     "http-server": "^0.8.0",
     "live-reload": "^1.1.0",
     "mkdirp": "^0.5.1",
+    "mocha": "^2.2.5",
     "nodemon": "^1.3.7",
     "opener": "^1.4.1",
     "parallelshell": "^1.2.0",
     "rimraf": "^2.4.1",
     "vulcanize": "^1.10.1",
-    "whatwg-fetch": "^0.9.0",
-    "webcomponents.js": "^0.7.2"
+    "webcomponents.js": "^0.7.2",
+    "jsdom": "^5.6.0",
+    "chai": "^3.2.0",
+    "whatwg-fetch": "^0.9.0"
   },
   "dependencies": {
     "ansi-to-html": "^0.3.0",
-    "transformime-commonmark": "0.0.1",
-    "mocha": "^2.2.5",
-    "jsdom": "^5.6.0",
-    "chai": "^3.2.0"
+    "katex": "^0.5.0",
+    "transformime-commonmark": "0.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import {StreamTransformer} from './stream.transformer';
 import {TracebackTransformer} from './traceback.transformer';
+import {LaTeXTransformer} from './latex.transformer';
 import {MarkdownTransformer} from 'transformime-commonmark';
 
 export default {StreamTransformer, TracebackTransformer, MarkdownTransformer};

--- a/src/latex.transformer.js
+++ b/src/latex.transformer.js
@@ -1,0 +1,15 @@
+"use strict";
+
+var katex = require('katex');
+
+export class LaTeXTransformer {
+    get mimetype() {
+        return 'text/latex';
+    }
+
+    transform(latex, doc) {
+        var el = doc.createElement('div');
+        el.innerHTML = katex.renderToString(latex);
+        return el;
+    }
+}


### PR DESCRIPTION
In support of #2.

```
> document = require('jsdom').jsdom();
> LaTeXTransformer = require('./lib/latex.transformer.js').LaTeXTransformer
Warning: KaTeX doesn't work in quirks mode. Make sure your website has a suitable doctype.
> lt = new LaTeXTransformer()
> el = lt.transform("x = 2")
> el.innerHTML
'<span class="katex"><span class="katex-mathml"><math><semantics><mrow><mi>x</mi><mo>=</mo><mn>2</mn></mrow><annotation encoding="application/x-tex">x = 2</annotation></semantics></math></span><span class="katex-html" aria-hidden="true"><span class="strut" style="height:0.64444em;"></span><span class="strut bottom" style="height:0.64444em;vertical-align:0em;"></span><span class="base textstyle uncramped"><span class="mord mathit">x</span><span class="mrel">=</span><span class="mord">2</span></span></span></span>'
```