### PR TITLE
Bring on the PDFs!

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,5 +2,6 @@ import {StreamTransformer} from './stream.transformer';
 import {TracebackTransformer} from './traceback.transformer';
 import {LaTeXTransformer} from './latex.transformer';
 import {MarkdownTransformer} from 'transformime-commonmark';
+import {PDFTransformer} from './pdf.transformer';
 
 export default {StreamTransformer, TracebackTransformer, MarkdownTransformer};

--- a/src/pdf.transformer.js
+++ b/src/pdf.transformer.js
@@ -1,0 +1,30 @@
+"use strict";
+
+/**
+ * Transform base 64 encoded PDF --> <a href="data:application/pdf;base64,...">
+ */
+export class PDFTransformer {
+    /**
+     * mimetype is application/pdf
+     * @return {string} application/pdf
+     */
+    get mimetype() {
+        return 'application/pdf';
+    }
+
+    /**
+     * transform a base64 encoded PDF string into the (current) Jupyter notebook
+     * version of the element. This one returns a little link you can click.
+     * @param  {string} base64PDF base64 encoded PDF
+     * @param  {Document} doc  A DOM (e.g. window.document)
+     * @return {HTMLElement}      A link element to the given PDF
+     */
+    transform(base64PDF, doc) {
+        var a = doc.createElement('a');
+        a.target = '_blank';
+        a.textContent = "View PDF";
+        a.href = 'data:application/pdf;base64,' + base64PDF;
+
+        return a;
+    }
+}


### PR DESCRIPTION
Another necessary for #2.

This does exactly what [outputarea.js does in the notebook](https://github.com/jupyter/notebook/blob/e8b3c1769366e2034d76d0b33206d3c5807620ea/notebook/static/notebook/js/outputarea.js#L738-L747) though in a jQuery-less "just use the DOM" way.