### PR TITLE
Fix SVGTransform

### DIFF
--- a/src/svg.transform.js
+++ b/src/svg.transform.js
@@ -1,11 +1,14 @@
 "use strict";
 
-export function SVGTransform(mimetype, value, document) {
-    // Create a div and append SVG XML to that div as HTML.  The SVG XML 
-    // includes the parent SVG tag, so all we need to do is return the first
-    // child element of the div == svg element.
-    var el = document.createElement('div');
-    el.innerHTML = value;
-    return el.firstChild;
+export function SVGTransform(mimetype, value, doc) {
+    const container = doc.createElement('div');
+    container.innerHTML = value;
+
+    const svgElement = container.getElementsByTagName('svg')[0];
+    if (!svgElement) {
+        throw new Error("SVGTransform: Error: Failed to create <svg> element");
+    }
+
+    return svgElement;
 }
 SVGTransform.mimetype = 'image/svg+xml';

--- a/test/svg.transform.test.js
+++ b/test/svg.transform.test.js
@@ -7,12 +7,25 @@ import {SVGTransform} from '../src/index';
 describe('svg transform', function() {
     beforeEach(function() {
         this.document = jsdom();
-        this.t = new Transformime([
-                SVGTransform
-            ]);
+        this.t = new Transformime([SVGTransform]);
     });
 
     it('should have the image/svg+xml mimetype', function() {
         assert.equal(SVGTransform.mimetype, 'image/svg+xml');
+    });
+
+    it('should create an svg tag', function() {
+        const svg = `
+            <?xml version="1.0" standalone="no"?>
+            <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+            SYSTEM "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+            <svg></svg>
+        `;
+        return this.t.transform({"image/svg+xml": svg}, this.document).then(
+            (bundle) => {
+                assert.equal(bundle.el.tagName, "svg");
+            },
+            (err) => { throw err; }
+        );
     });
 });


### PR DESCRIPTION
* `firstChild` doesn't necessarily return a node element (often the case
  in SVG files).

* Replaced `firstChild` with `getElementsByTagName`.

* Added test to avoid regressions.