### PR TITLE
ConsoleTextTransform: Use ansi_up

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "transformime": "^2.0.0"
   },
   "dependencies": {
-    "ansi-to-html": "^0.3.0",
+    "ansi_up": "^1.3.0",
     "katex": "^0.5.0",
     "transformime-commonmark": "^0.1.0"
   }

--- a/src/console-text.transform.js
+++ b/src/console-text.transform.js
@@ -1,22 +1,13 @@
 "use strict";
 
-var Convert = require('ansi-to-html');
+var ansi_up = require('ansi_up');
 
-export var consoleTextTransform = function() {
-    // Stick convert in a closure so it only gets created once.
-
-    let convert = new Convert({
-        escapeXML: true,
-        newLine: true
-    });
-
-    return function(mimetype, text, document) {
-        var el = document.createElement('pre');
-
-        el.innerHTML = convert.toHtml(text);
-        return el;
-    }
-} ();
+export function consoleTextTransform(mimetype, value, document) {
+    var el = document.createElement('pre');
+    var esc = ansi_up.escape_for_html(value);
+    el.innerHTML = ansi_up.ansi_to_html(esc);
+    return el;
+}
 
 
 consoleTextTransform.mimetype = 'jupyter/console-text';

--- a/test/console-text.transform.test.js
+++ b/test/console-text.transform.test.js
@@ -29,4 +29,16 @@ describe('console text transform', function() {
             assert.equal(el.localName, "pre");
         });
     });
+
+    it('should output the correct HTML with ansi colors', function() {
+        let consoleText = '\x1b[01;41;32mtext \x1b[00m';
+        let transformed =  this.t.transform(
+            {'jupyter/console-text': consoleText},
+            this.document);
+        return transformed.then(({el}) => {
+            assert.equal(el.outerHTML, '<pre><span style="color:rgb(0, 255, 0);background-color:rgb(187, 0, 0)">text </span></pre>');
+            assert.equal(el.textContent, 'text ');
+            assert.equal(el.localName, "pre");
+        });
+    });
 });


### PR DESCRIPTION
Use [`ansi_up`](https://github.com/drudru/ansi_up) for converting ANSI color escape codes.

This will allow to render all colors in [this notebook](https://github.com/nteract/notebook-test-data/blob/master/notebooks/ANSITest.ipynb) correctly.