### PR TITLE
LaTeXTransform: Escape math delimiters

### DIFF
--- a/src/latex.transform.js
+++ b/src/latex.transform.js
@@ -5,7 +5,7 @@ var mathjaxHelper = require('mathjax-electron');
 export function LaTeXTransform(mimetype, value, document) {
     var container = document.createElement('script');
     container.type = 'math/tex';
-    container.innerHTML = value.replace('<br>', '');
+    container.innerHTML = value.replace(/<br>|\$|\\\(|\\\)|\\\[|\\\]/g, '');
 
     mathjaxHelper.loadMathJax(document);
     mathjaxHelper.mathProcessor(container);


### PR DESCRIPTION
MathJax renders all text in math mode anyway.
`$`, `$$`, `\(...\)`, and `\[...]\` will be escaped in order to hide them in the output.