### PR TITLE
LaTeXTransform: Better mimik notebook behavior

### DIFF
--- a/src/latex.transform.js
+++ b/src/latex.transform.js
@@ -5,7 +5,7 @@ var mathjaxHelper = require('mathjax-electron');
 export function LaTeXTransform(mimetype, value, document) {
     var container = document.createElement('script');
     container.type = 'math/tex';
-    container.innerHTML = value.replace(/<br>|\$|\\\(|\\\)|\\\[|\\\]/g, '');
+    container.innerHTML = value.replace(/<br>|\$\$|^\$|\$$|\\\(|\\\)|\\\[|\\\]/g, '');
 
     mathjaxHelper.loadMathJax(document);
     mathjaxHelper.mathProcessor(container);


### PR DESCRIPTION
Allow a single `$` inside math text and only remove them at the beginning or end.