### PR TITLE
LaTeXTransform: Bump mathjax-electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,6 @@
   "dependencies": {
     "ansi_up": "^1.3.0",
     "transformime-commonmark": "^0.1.0",
-    "mathjax-electron": "^0.1.0"
+    "mathjax-electron": "^0.2.0"
   }
 }

--- a/src/latex.transform.js
+++ b/src/latex.transform.js
@@ -3,9 +3,8 @@
 var mathjaxHelper = require('mathjax-electron');
 
 export function LaTeXTransform(mimetype, value, document) {
-    var container = document.createElement('script');
-    container.type = 'math/tex';
-    container.innerHTML = value.replace(/<br>|\$\$|^\$|\$$|\\\(|\\\)|\\\[|\\\]/g, '');
+    var container = document.createElement('div');
+    container.innerHTML = value;
 
     mathjaxHelper.loadMathJax(document);
     mathjaxHelper.mathProcessor(container);

--- a/test/latex.transform.test.js
+++ b/test/latex.transform.test.js
@@ -19,9 +19,9 @@ describe('latex transform', function() {
         assert.equal(LaTeXTransform.mimetype, 'text/latex');
     });
 
-    it('should output the correct MathJax script', function() {
-        let latex = '\sum\limits_{i=0}^{\infty} \frac{1}{n^2}';
-        let mathJaxScript = '<script type="math/tex">\sum\limits_{i=0}^{\infty} \frac{1}{n^2}</script>';
+    it('should output the correct HTML', function() {
+        let latex = '$$\\sum\\limits_{i=0}^{\\infty} \\frac{1}{n^2}$$';
+        let mathJaxScript = '<div>$$\\sum\\limits_{i=0}^{\\infty} \\frac{1}{n^2}$$</div>';
         let transformed =  this.t.transform(
             {'text/latex': latex},
             this.document);


### PR DESCRIPTION
Now LaTeXTransform should be fully compatible with the jupyter notebook.

`mathjax-electron` uses the `tex2jax` extension to determine which part to render with MathJax (https://github.com/nteract/mathjax-electron/pull/2). This is exactly what the notebook is doing.